### PR TITLE
ADD IS_VALID_PTR macro:

### DIFF
--- a/include/elf/elf_manager.h
+++ b/include/elf/elf_manager.h
@@ -52,9 +52,11 @@ typedef char * ptr_t;
 			t_file	*f = (__F); 																\
 			int		ret = 1; 																	\
   																								\
-  			DEBUG_LOG(                                        									\
-			  "%s (%ld bytes), %p, %p", 														\
-			  #__TYPE, sizeof(__TYPE), p, (ptr_t)p + sizeof(__TYPE) 							\
+  			DEBUG_LOG(                                       									\
+			  "%s (%ld bytes), file map: [%p, %p], ptr: [%p, %p]", 								\
+			  #__TYPE, sizeof(__TYPE), 															\
+			  f->map, (ptr_t)f->map + f->stat.st_size, 											\
+			  p, (ptr_t)p + sizeof(__TYPE) 														\
 			);																					\
   																								\
 			if (p < (ptr_t)f->map || p + sizeof(__TYPE) > (ptr_t)f->map + f->stat.st_size)		\


### PR DESCRIPTION
Adding IS_VALID_PTR macro, to check whether a pointer of a given type can fit in a file's memory map.