### PR TITLE
    ADD injecting payload into executable:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ CC = clang
 SRC_LIST = 	main.c            \
 			elf/elf_manager.c \
 			payload/crypt.c   \
+			payload/inject.c  \
 			payload/payload.c \
 			utils/error.c     \
 			utils/file.c      \

--- a/include/elf/elf_manager.h
+++ b/include/elf/elf_manager.h
@@ -20,7 +20,7 @@ typedef struct s_elf_info {
 	size_t		sht_size;
 	Elf64_Off	entrypoint;
 	Elf64_Phdr	*exec_segment;
-	ptr_t		padding;
+	size_t		padding;
 	size_t		padding_size;
 	t_file		file;
 } t_elf_info;

--- a/include/elf/elf_manager.h
+++ b/include/elf/elf_manager.h
@@ -29,25 +29,4 @@ int		open_elf_file(t_elf_info *elf, const char *filename);
 int		parse_elf(t_elf_info *elf);
 void	elf_cleaner(t_elf_info *elf);
 
-/*
- * This macro is used to check whether a pointer of a given type can fit in a file's memory map.
- */
-#define IS_VALID_PTR(__PTR, __F, __TYPE) 														\
-		({																						\
-			ptr_t	p = (ptr_t)(__PTR); 														\
-			t_file	*f = (__F); 																\
-			int		ret = 1; 																	\
-  																								\
-  			DEBUG_LOG(                                       									\
-			  "%s (%ld bytes), file map: [%p, %p], ptr: [%p, %p]", 								\
-			  #__TYPE, sizeof(__TYPE), 															\
-			  f->map, (ptr_t)f->map + f->stat.st_size, 											\
-			  p, (ptr_t)p + sizeof(__TYPE) 														\
-			);																					\
-  																								\
-			if (p < (ptr_t)f->map || p + sizeof(__TYPE) > (ptr_t)f->map + f->stat.st_size)		\
-				ret = 0;																		\
-			ret; 																				\
-		})
-
 #endif //WW_PACKER_ELF_MANAGER_H

--- a/include/utils/file.h
+++ b/include/utils/file.h
@@ -15,6 +15,8 @@
 # include <stdlib.h>
 # include <unistd.h>
 
+# include "utils/debug.h"
+
 typedef struct s_file {
 	void 		*map;
 	const char	*filename;
@@ -26,5 +28,27 @@ int 	open_regular_file(const char *filename, t_file *file, int flags, mode_t mod
 int 	map_file(t_file *file, int prot, int flags);
 int 	clone_file(const char *new_filename, t_file *dst, t_file *src);
 int 	cmp_file(t_file *file1, t_file *file2);
+
+/*
+ * This macro is used to check whether a pointer of a given type can fit in a file's memory map.
+ */
+#define IS_VALID_PTR(__PTR, __F, __TYPE) 														\
+		({																						\
+			ptr_t	p = (ptr_t)(__PTR); 														\
+			t_file	*f = (__F); 																\
+			int		ret = 1; 																	\
+  																								\
+  			DEBUG_LOG(                                       									\
+			  "%s (%ld bytes), file map: [%p, %p], ptr: [%p, %p]", 								\
+			  #__TYPE, sizeof(__TYPE), 															\
+			  f->map, (ptr_t)f->map + f->stat.st_size, 											\
+			  p, (ptr_t)p + sizeof(__TYPE) 														\
+			);																					\
+  																								\
+			if (p < (ptr_t)f->map || p + sizeof(__TYPE) > (ptr_t)f->map + f->stat.st_size)		\
+				ret = 0;																		\
+			ret; 																				\
+		})
+
 
 #endif //WW_PACKER_FILE_H

--- a/include/woody.h
+++ b/include/woody.h
@@ -16,5 +16,6 @@ extern unsigned char	__bytecode[];
 extern unsigned int	__bytecode_len;
 
 void 	crypt_elf(t_elf_info *elf);
+void	inject(t_elf_info *elf);
 
 #endif //WW_PACKER_WOODY_H

--- a/include/woody.h
+++ b/include/woody.h
@@ -12,10 +12,9 @@
 
 # include "elf/elf_manager.h"
 
-extern unsigned const char	__bytecode[];
-extern unsigned const int	__bytecode_len;
+extern unsigned char	__bytecode[];
+extern unsigned int	__bytecode_len;
 
-char	*generate_key(char *dst, size_t len);
 void 	crypt_elf(t_elf_info *elf);
 
 #endif //WW_PACKER_WOODY_H

--- a/include/woody.h
+++ b/include/woody.h
@@ -15,7 +15,7 @@
 extern unsigned char	__bytecode[];
 extern unsigned int	__bytecode_len;
 
-void 	crypt_elf(t_elf_info *elf);
-void	inject(t_elf_info *elf);
+int		crypt_elf(t_elf_info *elf);
+int		inject(t_elf_info *elf);
 
 #endif //WW_PACKER_WOODY_H

--- a/srcs/elf/elf_manager.c
+++ b/srcs/elf/elf_manager.c
@@ -4,7 +4,6 @@
 
 #include <unistd.h>
 #include <stdlib.h>
-#include <stdio.h>
 
 #include "elf/elf_manager.h"
 #include "utils/error.h"
@@ -149,6 +148,7 @@ int parse_elf(t_elf_info *elf) {
 }
 
 void 	elf_cleaner(t_elf_info *elf) {
+	DEBUG_LOG("Cleaning up elf: %p, %p, %d", elf, elf->file.map, elf->file.fd);
 	if (!elf)
 		return ;
 	if (elf->file.map)

--- a/srcs/elf/elf_manager.c
+++ b/srcs/elf/elf_manager.c
@@ -52,10 +52,10 @@ int	get_padding(t_elf_info *elf) {
 
 	DEBUG_LOG("current is : %#lx", current);
 
-	elf->padding = (ptr_t)elf->exec_segment->p_offset + elf->exec_segment->p_memsz;
-	elf->padding_size = (ptr_t)current - elf->padding;
+	elf->padding = (size_t)elf->exec_segment->p_offset + elf->exec_segment->p_memsz;
+	elf->padding_size = current - elf->padding;
 
-	DEBUG_LOG("PADDING: %p padding sz: %#lx", elf->padding, elf->padding_size);
+	DEBUG_LOG("PADDING: %#lx padding sz: %#lx", elf->padding, elf->padding_size);
 
 	return (0);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -16,16 +16,18 @@ void	__attribute__((constructor)) debug_header(void) {
 #include "woody.h"
 
 int	main(int ac, char **av) {
-	t_elf_info elf;
+	t_elf_info elf __attribute__((cleanup(elf_cleaner))) = {0};
 	int ret;
 
 	if (ac != 2)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	if ((ret = open_elf_file(&elf, av[1])))
-		exit(ret);
+		return ret;
 	if ((ret = parse_elf(&elf)))
-		exit(ret);
-	crypt_elf(&elf);
-	inject(&elf);
+		return ret;
+	if ((ret = crypt_elf(&elf)))
+		return ret;
+	if ((ret = inject(&elf)))
+		return ret;
 	return (0);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -25,5 +25,7 @@ int	main(int ac, char **av) {
 		exit(ret);
 	if ((ret = parse_elf(&elf)))
 		exit(ret);
+	crypt_elf(&elf);
+	inject(&elf);
 	return (0);
 }

--- a/srcs/payload/crypt.c
+++ b/srcs/payload/crypt.c
@@ -10,9 +10,10 @@
 #include "utils/debug.h"
 #include "utils/random.h"
 #include "elf/elf_manager.h"
+#include "woody.h"
 
 
-char	*generate_key(char *dst, size_t len) {
+static unsigned char	*generate_key(unsigned char *dst, size_t len) {
 	char display_buf[len * 2];
 	char ret = 0;
 
@@ -39,16 +40,16 @@ static long	get_timestamp(void) {
 }
 
 void 	crypt_elf(t_elf_info *elf) {
-	char key[32] = {0};
+	unsigned char *key = __bytecode + __bytecode_len - 32;
 
 	ft_srand(get_timestamp());
-	generate_key(key, sizeof(key));
+	generate_key(key, 32);
 
 	char *const start = (char *)elf->file.map + elf->exec_segment->p_offset;
 	char *const end = start + elf->exec_segment->p_filesz;
 
 	DEBUG_LOG("Elf encryption (start: %p, end: %p)", start, end);
 	for (char *ptr = start; ptr < end; ptr++) {
-		*ptr ^= key[(ptr - start) % sizeof(key)];
+		*ptr ^= key[(ptr - start) % 32];
 	}
 }

--- a/srcs/payload/extract_bytecode.sh
+++ b/srcs/payload/extract_bytecode.sh
@@ -55,7 +55,7 @@ for line in $xxd_output; do
   echo -e "    ${gray}${addr}${reset}  ${bytecode}  ${gray}${memory}${reset}"
 done
 
-sed -i -E 's/^(unsigned).*(char|int)(.*)(\[\]|_len)/\1 const \2 __bytecode\4/g' "$script_dir"/payload.c
+sed -i -E 's/^(unsigned).*(char|int)(.*)(\[\]|_len)/\1 \2 __bytecode\4/g' "$script_dir"/payload.c
 
 echo -e "\n${bold}${green}Done${reset} ($script_dir/payload.c generated)"
 

--- a/srcs/payload/inject.c
+++ b/srcs/payload/inject.c
@@ -1,0 +1,28 @@
+#include "elf/elf_manager.h"
+#include "utils/string.h"
+#include "woody.h"
+
+void	inject(t_elf_info *elf) {
+
+	// filling payload with good offsets
+	size_t	seg_len_tmp = elf->exec_segment->p_filesz;
+	size_t	seg_off_tmp = elf->padding - elf->exec_segment->p_offset;
+	size_t	ep_off_tmp = elf->padding - elf->entrypoint;
+
+	ft_memcpy((__bytecode + __bytecode_len - 40), (&seg_len_tmp), sizeof(seg_len_tmp));
+	ft_memcpy((__bytecode + __bytecode_len - 48), (&seg_off_tmp), sizeof(seg_off_tmp));
+	ft_memcpy((__bytecode + __bytecode_len - 56), (&ep_off_tmp), sizeof(ep_off_tmp));
+	
+
+	// injecting payload	
+
+	ft_memcpy((elf->file.map + elf->padding), __bytecode, __bytecode_len);
+
+
+	// sign executable
+	*(int *)(elf->file.map + 9) = 0x574f4f57;
+
+	// change entrypoint in Ehdr
+	elf->header->e_entry = elf->padding;
+	
+}

--- a/srcs/payload/inject.c
+++ b/srcs/payload/inject.c
@@ -1,28 +1,34 @@
 #include "elf/elf_manager.h"
+#include "utils/error.h"
 #include "utils/string.h"
 #include "woody.h"
 
-void	inject(t_elf_info *elf) {
+int	inject(t_elf_info *elf) {
+	t_error error = { .data = &elf->file };
+
+	CUSTOM_PROTECT(
+		!IS_VALID_PTR(elf->file.map + elf->padding, &elf->file, sizeof(unsigned char) * __bytecode_len),
+		&error,
+		"Unable to inject payload, file is too small"
+	);
 
 	// filling payload with good offsets
-	size_t	seg_len_tmp = elf->exec_segment->p_filesz;
-	size_t	seg_off_tmp = elf->padding - elf->exec_segment->p_offset;
-	size_t	ep_off_tmp = elf->padding - elf->entrypoint;
+	size_t	seg_len = elf->exec_segment->p_filesz;
+	size_t	seg_off = elf->padding - elf->exec_segment->p_offset;
+	size_t	ep_off = elf->padding - elf->entrypoint;
 
-	ft_memcpy((__bytecode + __bytecode_len - 40), (&seg_len_tmp), sizeof(seg_len_tmp));
-	ft_memcpy((__bytecode + __bytecode_len - 48), (&seg_off_tmp), sizeof(seg_off_tmp));
-	ft_memcpy((__bytecode + __bytecode_len - 56), (&ep_off_tmp), sizeof(ep_off_tmp));
+	ft_memcpy((__bytecode + __bytecode_len - 40), (&seg_len), sizeof(seg_len));
+	ft_memcpy((__bytecode + __bytecode_len - 48), (&seg_off), sizeof(seg_off));
+	ft_memcpy((__bytecode + __bytecode_len - 56), (&ep_off), sizeof(ep_off));
 	
-
-	// injecting payload	
-
+	// injecting payload
 	ft_memcpy((elf->file.map + elf->padding), __bytecode, __bytecode_len);
-
 
 	// sign executable
 	*(int *)(elf->file.map + 9) = 0x574f4f57;
 
-	// change entrypoint in Ehdr
+	// change entrypoint in Elf header
 	elf->header->e_entry = elf->padding;
-	
+
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
First, we modify the deadbeef and cafebabe temporary variables into __bytecode with the corresponding offsets and size.
Then, we inject the final __bytecode into the executable file, with a new entrypoint and in the mean time, we add a signature into elf header from executable file to know we already packed it.

Close #13 .

