### PR TITLE
REWORK project structure:

### DIFF
--- a/include/elf/elf_manager.h
+++ b/include/elf/elf_manager.h
@@ -29,25 +29,4 @@ int		open_elf_file(t_elf_info *elf, const char *filename);
 int		parse_elf(t_elf_info *elf);
 void	elf_cleaner(t_elf_info *elf);
 
-/*
- * This macro is used to check whether a pointer of a given type can fit in a file's memory map.
- */
-#define IS_VALID_PTR(__PTR, __F, __TYPE) 														\
-		({																						\
-			ptr_t	p = (ptr_t)(__PTR); 														\
-			t_file	*f = (__F); 																\
-			int		ret = 1; 																	\
-  																								\
-  			DEBUG_LOG(                                       									\
-			  "%s (%ld bytes), file map: [%p, %p], ptr: [%p, %p]", 								\
-			  #__TYPE, sizeof(__TYPE), 															\
-			  f->map, (ptr_t)f->map + f->stat.st_size, 											\
-			  p, (ptr_t)p + sizeof(__TYPE) 														\
-			);																					\
-  																								\
-			if (p < (ptr_t)f->map || p + sizeof(__TYPE) > (ptr_t)f->map + f->stat.st_size)		\
-				ret = 0;																		\
-			ret; 																				\
-		})
-
 #endif //WW_PACKER_ELF_MANAGER_H

--- a/include/utils/file.h
+++ b/include/utils/file.h
@@ -15,6 +15,8 @@
 # include <stdlib.h>
 # include <unistd.h>
 
+# include "utils/debug.h"
+
 typedef struct s_file {
 	void 		*map;
 	const char	*filename;
@@ -26,5 +28,27 @@ int 	open_regular_file(const char *filename, t_file *file, int flags, mode_t mod
 int 	map_file(t_file *file, int prot, int flags);
 int 	clone_file(const char *new_filename, t_file *dst, t_file *src);
 int 	cmp_file(t_file *file1, t_file *file2);
+
+/*
+ * This macro is used to check whether a pointer of a given type can fit in a file's memory map.
+ */
+#define IS_VALID_PTR(__PTR, __F, __TYPE) 														\
+		({																						\
+			ptr_t	p = (ptr_t)(__PTR); 														\
+			t_file	*f = (__F); 																\
+			int		ret = 1; 																	\
+  																								\
+  			DEBUG_LOG(                                       									\
+			  "%s (%ld bytes), file map: [%p, %p], ptr: [%p, %p]", 								\
+			  #__TYPE, sizeof(__TYPE), 															\
+			  f->map, (ptr_t)f->map + f->stat.st_size, 											\
+			  p, (ptr_t)p + sizeof(__TYPE) 														\
+			);																					\
+  																								\
+			if (p < (ptr_t)f->map || p + sizeof(__TYPE) > (ptr_t)f->map + f->stat.st_size)		\
+				ret = 0;																		\
+			ret; 																				\
+		})
+
 
 #endif //WW_PACKER_FILE_H

--- a/include/woody.h
+++ b/include/woody.h
@@ -15,7 +15,7 @@
 extern unsigned char	__bytecode[];
 extern unsigned int	__bytecode_len;
 
-void 	crypt_elf(t_elf_info *elf);
-void	inject(t_elf_info *elf);
+int		crypt_elf(t_elf_info *elf);
+int		inject(t_elf_info *elf);
 
 #endif //WW_PACKER_WOODY_H

--- a/srcs/elf/elf_manager.c
+++ b/srcs/elf/elf_manager.c
@@ -4,7 +4,6 @@
 
 #include <unistd.h>
 #include <stdlib.h>
-#include <stdio.h>
 
 #include "elf/elf_manager.h"
 #include "utils/error.h"
@@ -149,6 +148,7 @@ int parse_elf(t_elf_info *elf) {
 }
 
 void 	elf_cleaner(t_elf_info *elf) {
+	DEBUG_LOG("Cleaning up elf: %p, %p, %d", elf, elf->file.map, elf->file.fd);
 	if (!elf)
 		return ;
 	if (elf->file.map)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -16,16 +16,18 @@ void	__attribute__((constructor)) debug_header(void) {
 #include "woody.h"
 
 int	main(int ac, char **av) {
-	t_elf_info elf;
+	t_elf_info elf __attribute__((cleanup(elf_cleaner))) = {0};
 	int ret;
 
 	if (ac != 2)
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	if ((ret = open_elf_file(&elf, av[1])))
-		exit(ret);
+		return ret;
 	if ((ret = parse_elf(&elf)))
-		exit(ret);
-	crypt_elf(&elf);
-	inject(&elf);
+		return ret;
+	if ((ret = crypt_elf(&elf)))
+		return ret;
+	if ((ret = inject(&elf)))
+		return ret;
 	return (0);
 }

--- a/srcs/payload/inject.c
+++ b/srcs/payload/inject.c
@@ -1,28 +1,34 @@
 #include "elf/elf_manager.h"
+#include "utils/error.h"
 #include "utils/string.h"
 #include "woody.h"
 
-void	inject(t_elf_info *elf) {
+int	inject(t_elf_info *elf) {
+	t_error error = { .data = &elf->file };
+
+	CUSTOM_PROTECT(
+		!IS_VALID_PTR(elf->file.map + elf->padding, &elf->file, sizeof(unsigned char) * __bytecode_len),
+		&error,
+		"Unable to inject payload, file is too small"
+	);
 
 	// filling payload with good offsets
-	size_t	seg_len_tmp = elf->exec_segment->p_filesz;
-	size_t	seg_off_tmp = elf->padding - elf->exec_segment->p_offset;
-	size_t	ep_off_tmp = elf->padding - elf->entrypoint;
+	size_t	seg_len = elf->exec_segment->p_filesz;
+	size_t	seg_off = elf->padding - elf->exec_segment->p_offset;
+	size_t	ep_off = elf->padding - elf->entrypoint;
 
-	ft_memcpy((__bytecode + __bytecode_len - 40), (&seg_len_tmp), sizeof(seg_len_tmp));
-	ft_memcpy((__bytecode + __bytecode_len - 48), (&seg_off_tmp), sizeof(seg_off_tmp));
-	ft_memcpy((__bytecode + __bytecode_len - 56), (&ep_off_tmp), sizeof(ep_off_tmp));
+	ft_memcpy((__bytecode + __bytecode_len - 40), (&seg_len), sizeof(seg_len));
+	ft_memcpy((__bytecode + __bytecode_len - 48), (&seg_off), sizeof(seg_off));
+	ft_memcpy((__bytecode + __bytecode_len - 56), (&ep_off), sizeof(ep_off));
 	
-
-	// injecting payload	
-
+	// injecting payload
 	ft_memcpy((elf->file.map + elf->padding), __bytecode, __bytecode_len);
-
 
 	// sign executable
 	*(int *)(elf->file.map + 9) = 0x574f4f57;
 
-	// change entrypoint in Ehdr
+	// change entrypoint in Elf header
 	elf->header->e_entry = elf->padding;
-	
+
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Using of return instead of exit, to ensure cleanup are called.
Adding forgotten cleanup attribute to main elf structure.
Adding some pointer checks on crypt_elf and inject functions.
Moving IS_VALID_PTR macro from elf_manager.h to file.h.